### PR TITLE
Pin 3rd-party actions to SHA1

### DIFF
--- a/.github/workflows/generate_clients.yaml
+++ b/.github/workflows/generate_clients.yaml
@@ -21,7 +21,7 @@ jobs:
         make generate
         make generate-errors
     - name: Add & Commit
-      uses: EndBug/add-and-commit@v9.0.1
+      uses: EndBug/add-and-commit@998652d28d7702d095d40f52ae42982a80ae8c7d #v9.0.1
       with:
         add: ./sdks/*
         message: "chore(sdk): generate SDKs"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@a362e5fb42057a3a23a62218b050838f1bacca5d #v4
       - name: Use python
         uses: actions/setup-python@v1
         with:
@@ -24,6 +24,6 @@ jobs:
         run: make build
       - name: Publish distribution 📦 to Test PyPI
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@c7f29f7adef1a245bd91520e94867e5c6eedddcc #release/v1
         with:
           password: ${{ secrets.RHOAS_PYPI_API_TOKEN }}

--- a/.github/workflows/update_openapi.yaml
+++ b/.github/workflows/update_openapi.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Fetch OpenAPI doc
         if: github.event.client_payload.download_url != ''
         run: ./scripts/fetch_api.sh ${{ github.event.client_payload.download_url }}
-      - uses: peter-evans/create-pull-request@v4
+      - uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 #v4
         with:
           title: "chore(openapi): update ${{ env.CLIENT_ID }} OpenAPI document"
           token: "${{ secrets.CI_USER_TOKEN }}"


### PR DESCRIPTION
Hi!

Following the [GH Action Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) guide we should use the commit SHA instead of the `branch` or `tag` for any third-party untrusted action.

This PR was submitted by a script.
